### PR TITLE
CUDA check before importing xFormers.

### DIFF
--- a/dinov2/layers/attention.py
+++ b/dinov2/layers/attention.py
@@ -68,7 +68,7 @@ class Attention(nn.Module):
 
 class MemEffAttention(Attention):
     def forward(self, x: Tensor, attn_bias=None) -> Tensor:
-        if not XFORMERS_AVAILABLE:
+        if not XFORMERS_AVAILABLE or not x.is_cuda:
             assert attn_bias is None, "xFormers is required for nested tensors usage"
             return super().forward(x)
 

--- a/dinov2/layers/attention.py
+++ b/dinov2/layers/attention.py
@@ -12,18 +12,22 @@ import logging
 
 from torch import Tensor
 from torch import nn
+from torch import cuda
+
+HAS_CUDA = cuda.is_available()
 
 
 logger = logging.getLogger("dinov2")
 
 
-try:
-    from xformers.ops import memory_efficient_attention, unbind, fmha
+XFORMERS_AVAILABLE = False
+if HAS_CUDA:
+    try:
+        from xformers.ops import memory_efficient_attention, unbind, fmha
 
-    XFORMERS_AVAILABLE = True
-except ImportError:
-    logger.warning("xFormers not available")
-    XFORMERS_AVAILABLE = False
+        XFORMERS_AVAILABLE = True
+    except ImportError:
+        logger.warning("xFormers not available")
 
 
 class Attention(nn.Module):

--- a/dinov2/layers/block.py
+++ b/dinov2/layers/block.py
@@ -19,18 +19,21 @@ from .drop_path import DropPath
 from .layer_scale import LayerScale
 from .mlp import Mlp
 
+HAS_CUDA = torch.cuda.is_available()
+
 
 logger = logging.getLogger("dinov2")
 
 
-try:
-    from xformers.ops import fmha
-    from xformers.ops import scaled_index_add, index_select_cat
+XFORMERS_AVAILABLE = False
+if HAS_CUDA:
+    try:
+        from xformers.ops import fmha
+        from xformers.ops import scaled_index_add, index_select_cat
 
-    XFORMERS_AVAILABLE = True
-except ImportError:
-    logger.warning("xFormers not available")
-    XFORMERS_AVAILABLE = False
+        XFORMERS_AVAILABLE = True
+    except ImportError:
+        logger.warning("xFormers not available")
 
 
 class Block(nn.Module):


### PR DESCRIPTION
I don't know how useful this might be, but in some cases attempts to run DINOv2 on CPU would fail because the xformers requirement could be satisfied, but the model itself is not on CUDA.

This adds a few lines to attention and block to checks if torch was compiled with CUDA before attempting to import xFormers. 
Regardless of whether CUDA is available or not, torch needs to be compiled with CUDA in order for tensors to be mappable to device, so if it's not, attempting to import xFormers might succeed if the user has xFormers installed in their environment.

Related issue: #3 .