### PR TITLE
Exclude venv from flake8 linting

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -3,3 +3,5 @@ max-line-length = 120
 ignore = E203,E501,W503
 per-file-ignores =
   __init__.py:F401
+exclude =
+    venv


### PR DESCRIPTION
Issue: flake8 processes the venv dir.
Change: added `exclude = venv` to flake8 conf