### PR TITLE
Remove mutable default arguments

### DIFF
--- a/dinov2/eval/knn.py
+++ b/dinov2/eval/knn.py
@@ -29,9 +29,10 @@ logger = logging.getLogger("dinov2")
 
 def get_args_parser(
     description: Optional[str] = None,
-    parents: Optional[List[argparse.ArgumentParser]] = [],
+    parents: Optional[List[argparse.ArgumentParser]] = None,
     add_help: bool = True,
 ):
+    parents = parents or []
     setup_args_parser = get_setup_args_parser(parents=parents, add_help=False)
     parents = [setup_args_parser]
     parser = argparse.ArgumentParser(

--- a/dinov2/eval/linear.py
+++ b/dinov2/eval/linear.py
@@ -33,9 +33,10 @@ logger = logging.getLogger("dinov2")
 
 def get_args_parser(
     description: Optional[str] = None,
-    parents: Optional[List[argparse.ArgumentParser]] = [],
+    parents: Optional[List[argparse.ArgumentParser]] = None,
     add_help: bool = True,
 ):
+    parents = parents or []
     setup_args_parser = get_setup_args_parser(parents=parents, add_help=False)
     parents = [setup_args_parser]
     parser = argparse.ArgumentParser(

--- a/dinov2/eval/log_regression.py
+++ b/dinov2/eval/log_regression.py
@@ -38,9 +38,10 @@ _CPU_DEVICE = torch.device("cpu")
 
 def get_args_parser(
     description: Optional[str] = None,
-    parents: Optional[List[argparse.ArgumentParser]] = [],
+    parents: Optional[List[argparse.ArgumentParser]] = None,
     add_help: bool = True,
 ):
+    parents = parents or []
     setup_args_parser = get_setup_args_parser(parents=parents, add_help=False)
     parents = [setup_args_parser]
     parser = argparse.ArgumentParser(

--- a/dinov2/eval/setup.py
+++ b/dinov2/eval/setup.py
@@ -17,12 +17,12 @@ import dinov2.utils.utils as dinov2_utils
 
 def get_args_parser(
     description: Optional[str] = None,
-    parents: Optional[List[argparse.ArgumentParser]] = [],
+    parents: Optional[List[argparse.ArgumentParser]] = None,
     add_help: bool = True,
 ):
     parser = argparse.ArgumentParser(
         description=description,
-        parents=parents,
+        parents=parents or [],
         add_help=add_help,
     )
     parser.add_argument(

--- a/dinov2/run/submit.py
+++ b/dinov2/run/submit.py
@@ -24,9 +24,10 @@ logger = logging.getLogger("dinov2")
 
 def get_args_parser(
     description: Optional[str] = None,
-    parents: Optional[List[argparse.ArgumentParser]] = [],
+    parents: Optional[List[argparse.ArgumentParser]] = None,
     add_help: bool = True,
 ) -> argparse.ArgumentParser:
+    parents = parents or []
     slurm_partition = get_slurm_partition()
     parser = argparse.ArgumentParser(
         description=description,


### PR DESCRIPTION
Passing a list as arg is [unrecommended](https://runestone.academy/ns/books/published/thinkcspy/Lists/UsingListsasParameters.html).
So, I replaced such code with a safer way.