### PR TITLE
Allow disabling xFormers via environment variable

### DIFF
--- a/dinov2/layers/attention.py
+++ b/dinov2/layers/attention.py
@@ -23,6 +23,7 @@ XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
     if XFORMERS_ENABLED:
         from xformers.ops import memory_efficient_attention, unbind
+
         XFORMERS_AVAILABLE = True
         warnings.warn("xFormers is available (Attention)")
     else:

--- a/dinov2/layers/attention.py
+++ b/dinov2/layers/attention.py
@@ -9,6 +9,8 @@
 #   https://github.com/rwightman/pytorch-image-models/tree/master/timm/models/vision_transformer.py
 
 import logging
+import os
+import warnings
 
 from torch import Tensor
 from torch import nn
@@ -17,13 +19,18 @@ from torch import nn
 logger = logging.getLogger("dinov2")
 
 
+XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
-    from xformers.ops import memory_efficient_attention, unbind, fmha
-
-    XFORMERS_AVAILABLE = True
+    if XFORMERS_ENABLED:
+        from xformers.ops import memory_efficient_attention, unbind
+        XFORMERS_AVAILABLE = True
+        warnings.warn("xFormers is available (Attention)")
+    else:
+        warnings.warn("xFormers is disabled (Attention)")
+        raise ImportError
 except ImportError:
-    logger.warning("xFormers not available")
     XFORMERS_AVAILABLE = False
+    warnings.warn("xFormers is not available (Attention)")
 
 
 class Attention(nn.Module):
@@ -65,7 +72,8 @@ class Attention(nn.Module):
 class MemEffAttention(Attention):
     def forward(self, x: Tensor, attn_bias=None) -> Tensor:
         if not XFORMERS_AVAILABLE:
-            assert attn_bias is None, "xFormers is required for nested tensors usage"
+            if attn_bias is not None:
+                raise AssertionError("xFormers is required for using nested tensors")
             return super().forward(x)
 
         B, N, C = x.shape

--- a/dinov2/layers/block.py
+++ b/dinov2/layers/block.py
@@ -29,6 +29,7 @@ XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
     if XFORMERS_ENABLED:
         from xformers.ops import fmha, scaled_index_add, index_select_cat
+
         XFORMERS_AVAILABLE = True
         warnings.warn("xFormers is available (Block)")
     else:
@@ -38,8 +39,6 @@ except ImportError:
     XFORMERS_AVAILABLE = False
 
     warnings.warn("xFormers is not available (Block)")
-
-
 
 
 class Block(nn.Module):

--- a/dinov2/layers/swiglu_ffn.py
+++ b/dinov2/layers/swiglu_ffn.py
@@ -39,6 +39,7 @@ XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
     if XFORMERS_ENABLED:
         from xformers.ops import SwiGLU
+
         XFORMERS_AVAILABLE = True
         warnings.warn("xFormers is available (SwiGLU)")
     else:

--- a/dinov2/layers/swiglu_ffn.py
+++ b/dinov2/layers/swiglu_ffn.py
@@ -4,7 +4,9 @@
 # This source code is licensed under the license found in the
 # LICENSE file in the root directory of this source tree.
 
+import os
 from typing import Callable, Optional
+import warnings
 
 from torch import Tensor, nn
 import torch.nn.functional as F
@@ -33,13 +35,20 @@ class SwiGLUFFN(nn.Module):
         return self.w3(hidden)
 
 
+XFORMERS_ENABLED = os.environ.get("XFORMERS_DISABLED") is None
 try:
-    from xformers.ops import SwiGLU
-
-    XFORMERS_AVAILABLE = True
+    if XFORMERS_ENABLED:
+        from xformers.ops import SwiGLU
+        XFORMERS_AVAILABLE = True
+        warnings.warn("xFormers is available (SwiGLU)")
+    else:
+        warnings.warn("xFormers is disabled (SwiGLU)")
+        raise ImportError
 except ImportError:
     SwiGLU = SwiGLUFFN
     XFORMERS_AVAILABLE = False
+
+    warnings.warn("xFormers is not available (SwiGLU)")
 
 
 class SwiGLUFFNFused(SwiGLU):

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -19,13 +19,11 @@ from dinov2.fsdp import get_fsdp_wrapper, ShardedGradScaler, get_fsdp_modules, r
 
 from dinov2.models.vision_transformer import BlockChunk
 
+
 try:
     from xformers.ops import fmha
-
-    XFORMERS_AVAILABLE = True
 except ImportError:
-    XFORMERS_AVAILABLE = False
-assert XFORMERS_AVAILABLE, "xFormers is required for DINOv2 training"
+    raise AssertionError("xFormers is required for training")
 
 
 logger = logging.getLogger("dinov2")


### PR DESCRIPTION
Allow disabling the use of xFormers (for inference) by simply setting the XFORMERS_DISABLED environment variable (also add copious amount of warnings). This can be useful in case the xFormers library is installed in the environment but the model is used (or just tested) on a CPU or on a GPU that is not supported by the xFormers operators. Additionally replaced asserts with raising AssertionError instead.