### PR TITLE
Add (optional) extras dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,19 @@ conda activate dinov2
 pip install -r requirements.txt
 ```
 
+For dense tasks (depth estimation and semantic segmentation), there are additional dependencies (specific versions of `mmcv` and `mmsegmentation`) which are captured in the `extras` dependency specifications:
+
+*[conda](https://docs.conda.io/projects/conda/en/latest/user-guide/getting-started.html)* **(Recommended)**:
+
+```shell
+conda env create -f conda-extras.yaml
+conda activate dinov2-extras
+```
+
+*[pip](https://pip.pypa.io/en/stable/getting-started/)*:
+
+pip install -r requirements.txt -r requirements-extras.txt
+
 ## Data preparation
 
 ### ImageNet-1k

--- a/conda-extras.yaml
+++ b/conda-extras.yaml
@@ -1,0 +1,24 @@
+name: dinov2-extras
+channels:
+  - defaults
+  - pytorch
+  - nvidia
+  - xformers
+  - conda-forge
+dependencies:
+  - python=3.9
+  - pytorch::pytorch=2.0.0
+  - pytorch::pytorch-cuda=11.7.0
+  - pytorch::torchvision=0.15.0
+  - omegaconf
+  - torchmetrics=0.10.3
+  - fvcore
+  - iopath
+  - xformers::xformers=0.0.18
+  - pip
+  - pip:
+    - git+https://github.com/facebookincubator/submitit
+    - --extra-index-url https://pypi.nvidia.com
+    - cuml-cu11
+    - mmcv-full==1.5.0
+    - mmsegmentation==0.27.0

--- a/requirements-extras.txt
+++ b/requirements-extras.txt
@@ -1,0 +1,2 @@
+mmcv-full==1.5.0
+mmsegmentation==0.27.0

--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,7 @@ def get_package_version() -> str:
 requirements, extra_indices = get_requirements()
 version = get_package_version()
 dev_requirements, _ = get_requirements(HERE / "requirements-dev.txt")
+extras_requirements, _ = get_requirements(HERE / "requirements-extras.txt")
 
 
 setup(
@@ -66,10 +67,11 @@ setup(
         "": ["*.yaml"],
     },
     install_requires=requirements,
-    dependency_links=extra_indices,
     extras_require={
         "dev": dev_requirements,
+        "extras": extras_requirements,
     },
+    dependency_links=extra_indices,
     install_package_data=True,
     license="Apache",
     license_files=("LICENSE",),


### PR DESCRIPTION
Add (optional) extras dependencies for dense tasks (mmcv and mmsegmentation) to conda and pip requirements.