### PR TITLE
fixing the probability of applying GaussianBlur

### DIFF
--- a/dinov2/data/transforms.py
+++ b/dinov2/data/transforms.py
@@ -15,10 +15,8 @@ class GaussianBlur(transforms.RandomApply):
     """
 
     def __init__(self, *, p: float = 0.5, radius_min: float = 0.1, radius_max: float = 2.0):
-        # NOTE: torchvision is applying 1 - probability to return the original image
-        keep_p = 1 - p
         transform = transforms.GaussianBlur(kernel_size=9, sigma=(radius_min, radius_max))
-        super().__init__(transforms=[transform], p=keep_p)
+        super().__init__(transforms=[transform], p=p)
 
 
 class MaybeToTensor(transforms.ToTensor):


### PR DESCRIPTION
Hi,
I've identified a potential issue within the data augmentation pipeline of DINOv2 that appears to deviate from the expected behavior observed in DINO and MoCo-v3. According to the source code for [DINO](https://github.com/facebookresearch/dino/blob/7c446df5b9f45747937fb0d72314eb9f7b66930a/main_dino.py#L438) and [MoCo-v3](https://github.com/facebookresearch/moco-v3/blob/c349e6e24f40d3fedb22d973f92defa4cedf37a7/main_moco.py#L268), a Gaussian blur is consistently applied to the first global crop. However, in [DINOv2](https://github.com/facebookresearch/dinov2/blob/e1277af2ba9496fbadf7aec6eba56e8d882d1e35/dinov2/data/augmentations.py#L73), the probability within the GaussianBlur class is erroneously [inverted](https://github.com/facebookresearch/dinov2/blob/e1277af2ba9496fbadf7aec6eba56e8d882d1e35/dinov2/data/transforms.py#L19). This is contrary to the documentation and implementation of [RandomApply](https://github.com/pytorch/vision/blob/fa99a5360fbcd1683311d57a76fcc0e7323a4c1e/torchvision/transforms/transforms.py#L544) in TorchVision, where `p=1` should indeed apply the transformation consistently.

The rectification is straightforward—alter the probability handling to align with the standard expectations. However, this raises two significant questions:

    1. Are the pretrained models also affected by this anomaly in data augmentation?
    2. If so, what impact might this have on their performance and reliability?