### PR TITLE
add the sys.path way to help finding the dinov2 in using VSCODE

### DIFF
--- a/dinov2/run/train/train.py
+++ b/dinov2/run/train/train.py
@@ -7,6 +7,8 @@ import logging
 import os
 import sys
 
+sys.path.append(os.path.dirname(os.path.abspath(__file__)) + '/../../..')
+
 from dinov2.logging import setup_logging
 from dinov2.train import get_args_parser as get_train_args_parser
 from dinov2.run.submit import get_args_parser, submit_jobs


### PR DESCRIPTION
In ubuntu 22.04 OS, "No module named 'dinov2'" would be happen if you run the train.py in /dinov2/run/train, I found that some people asked about it in issue, using the sys.path.append to add the path could help the interpreter to find the right "dinov2" and fix the error mentioned before.