### PR TITLE
Remove unnecessary warnings

### DIFF
--- a/dinov2/layers/attention.py
+++ b/dinov2/layers/attention.py
@@ -24,7 +24,6 @@ try:
         from xformers.ops import memory_efficient_attention, unbind
 
         XFORMERS_AVAILABLE = True
-        warnings.warn("xFormers is available (Attention)")
     else:
         warnings.warn("xFormers is disabled (Attention)")
         raise ImportError

--- a/dinov2/layers/block.py
+++ b/dinov2/layers/block.py
@@ -30,7 +30,6 @@ try:
         from xformers.ops import fmha, scaled_index_add, index_select_cat
 
         XFORMERS_AVAILABLE = True
-        warnings.warn("xFormers is available (Block)")
     else:
         warnings.warn("xFormers is disabled (Block)")
         raise ImportError

--- a/dinov2/layers/swiglu_ffn.py
+++ b/dinov2/layers/swiglu_ffn.py
@@ -40,7 +40,6 @@ try:
         from xformers.ops import SwiGLU
 
         XFORMERS_AVAILABLE = True
-        warnings.warn("xFormers is available (SwiGLU)")
     else:
         warnings.warn("xFormers is disabled (SwiGLU)")
         raise ImportError


### PR DESCRIPTION
There should be no warning when xFormers is available. There is a warning in every code path and it spams my training logs.