### PR TITLE
Fix: x.item() can not be called when creating the model on a "meta" device

### DIFF
--- a/dinov2/models/vision_transformer.py
+++ b/dinov2/models/vision_transformer.py
@@ -12,6 +12,7 @@ import math
 import logging
 from typing import Sequence, Tuple, Union, Callable
 
+import numpy as np
 import torch
 import torch.nn as nn
 import torch.utils.checkpoint
@@ -116,7 +117,7 @@ class DinoVisionTransformer(nn.Module):
         if drop_path_uniform is True:
             dpr = [drop_path_rate] * depth
         else:
-            dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
+            dpr = np.linspace(0, drop_path_rate, depth).tolist()  # stochastic depth decay rule
 
         if ffn_layer == "mlp":
             logger.info("using MLP layer as FFN")


### PR DESCRIPTION
Context: I want to load an empty DINOv2 model without pretrained weights on a meta device.

Issue: the constructor uses `torch.linspace()` and calls `.item()` on its elements, which gives an error when used inside a meta device context:

```python
with torch.device("meta"):
    model = torch.hub.load("facebookresearch/dinov2", "dinov2_vits14_reg", pretrained=False)

# RuntimeError: Tensor.item() cannot be called on meta tensors
# File: dinov2/models/vision_transformer.py", line 119, in <listcomp>
#    dpr = [x.item() for x in torch.linspace(0, drop_path_rate, depth)]  # stochastic depth decay rule
```

Solution: use numpy for creating the list of drop path rates:
```python
with torch.device("meta"):
    model = torch.hub.load("baldassarrefe/dinov2:patch-2", "dinov2_vits14_reg", pretrained=False)
# all good
```