### PR TITLE
Fix broken URL in pretrained heads for classification

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ dinov2_vitg14_reg = torch.hub.load('facebookresearch/dinov2', 'dinov2_vitg14_reg
       <td>ViT-g/14</td>
       <td align="center">:white_check_mark:</td>
       <td>
-        linear head (<a href="https://dl.fbaipublicfiles.com/dinov2/dinov2_vitg14/dinov2_vitg14_lreg4_inear_head.pth">1 layer</a>,
+        linear head (<a href="https://dl.fbaipublicfiles.com/dinov2/dinov2_vitg14/dinov2_vitg14_reg4_linear_head.pth">1 layer</a>,
         <a href="https://dl.fbaipublicfiles.com/dinov2/dinov2_vitg14/dinov2_vitg14_reg4_linear4_head.pth">4 layers</a>)
     </tr>
   </tbody>


### PR DESCRIPTION
This PR fixes a broken URL in the Pretrained heads - Image classification table.

The previous link incorrectly pointed to `dinov2_vitg14_lreg4_inear_head.pth`, which was a typo. 

<img width="953" height="190" alt="image" src="https://github.com/user-attachments/assets/bb2d04e4-b124-42c1-9dad-c15810229482" />


It has been corrected to `dinov2_vitg14_reg4_linear_head.pth`.