### PR TITLE
Remove xFormers enabled warning for block, attention and swiglu

### DIFF
--- a/dinov2/layers/attention.py
+++ b/dinov2/layers/attention.py
@@ -24,7 +24,6 @@ try:
         from xformers.ops import memory_efficient_attention, unbind
 
         XFORMERS_AVAILABLE = True
-        warnings.warn("xFormers is available (Attention)")
     else:
         warnings.warn("xFormers is disabled (Attention)")
         raise ImportError

--- a/dinov2/layers/block.py
+++ b/dinov2/layers/block.py
@@ -30,7 +30,6 @@ try:
         from xformers.ops import fmha, scaled_index_add, index_select_cat
 
         XFORMERS_AVAILABLE = True
-        warnings.warn("xFormers is available (Block)")
     else:
         warnings.warn("xFormers is disabled (Block)")
         raise ImportError

--- a/dinov2/layers/swiglu_ffn.py
+++ b/dinov2/layers/swiglu_ffn.py
@@ -40,7 +40,6 @@ try:
         from xformers.ops import SwiGLU
 
         XFORMERS_AVAILABLE = True
-        warnings.warn("xFormers is available (SwiGLU)")
     else:
         warnings.warn("xFormers is disabled (SwiGLU)")
         raise ImportError


### PR DESCRIPTION
## Summary 

This PR modifies the logging behavior in the dinov2 model's core modules (SwiGLU, Attention, and Block) to remove/replace the `warnings.warn` calls about xFormers availability.

## Motivation

The existing code raises `UserWarnings` like:
```
/home/user/.cache/torch/hub/facebookresearch_dinov2_main/dinov2/layers/swiglu_ffn.py:43: UserWarning: xFormers is available (SwiGLU)
  warnings.warn("xFormers is available (SwiGLU)")
/home/user/.cache/torch/hub/facebookresearch_dinov2_main/dinov2/layers/attention.py:27: UserWarning: xFormers is available (Attention)
  warnings.warn("xFormers is available (Attention)")
/home/user/.cache/torch/hub/facebookresearch_dinov2_main/dinov2/layers/block.py:33: UserWarning: xFormers is available (Block)
  warnings.warn("xFormers is available (Block)")
```

Since warnings generally indicate potential issues, this can be misleading or distracting to users—especially when everything is functioning correctly.

## Benefits
- Reduces unnecessary noise in logs for users who already have `xFormers` set up.
- Prevents confusion by accurately reflecting the status as an informational message rather than a warning.

## Alternative solution

Replace `warnings.warn(...)` with `logging.info(...)` to keep the developer awareness that `xFormers` is being utilized, without implying a problem.
