### PR TITLE
Fix conceptually incorrect, non-breaking image shape tuple unpacking.

### DIFF
--- a/dinov2/models/vision_transformer.py
+++ b/dinov2/models/vision_transformer.py
@@ -214,7 +214,7 @@ class DinoVisionTransformer(nn.Module):
         return torch.cat((class_pos_embed.unsqueeze(0), patch_pos_embed), dim=1).to(previous_dtype)
 
     def prepare_tokens_with_masks(self, x, masks=None):
-        B, nc, w, h = x.shape
+þþ        B, nc, h, w = x.shape
         x = self.patch_embed(x)
         if masks is not None:
             x = torch.where(masks.unsqueeze(-1), self.mask_token.to(x.dtype).unsqueeze(0), x)


### PR DESCRIPTION
In the current implementation, the code unpacks the tensor shape as: B, nc, w, h = x.shape

In PyTorch, the standard memory layout for 4D tensors is NCHW. By assigning the third dimension to W and the fourth to H, the spatial dimensions are logically inverted. For models trained on square images, this has zero impact on performance as H=W.

If this ViT class is used in future research for non-square inputs (e.g., 384×512), the positional embeddings will be calculated using incorrect spatial coordinates. This leads to a misalignment between the input patches and their corresponding positional encodings, potentially degrading model convergence and downstream performance.

I believe this error has propagated from DINO, and is not existent in DINOv3.