### PR TITLE
Fix: iBOT sinkhorn teacher for single process runs

### DIFF
--- a/dinov2/loss/ibot_patch_loss.py
+++ b/dinov2/loss/ibot_patch_loss.py
@@ -65,7 +65,8 @@ class iBOTPatchLoss(nn.Module):
         Q = torch.exp(teacher_output / teacher_temp).t()  # Q is K-by-B for consistency with notations from our paper
         # B = Q.shape[1] * world_size # number of samples to assign
         B = n_masked_patches_tensor
-        dist.all_reduce(B)
+        if dist.is_initialized():
+            dist.all_reduce(B)
         K = Q.shape[0]  # how many prototypes
 
         # make the matrix sums to 1


### PR DESCRIPTION
This fixes a single-process compatibility issue in `iBOTPatchLoss.sinkhorn_knopp_teacher()`.

Currently the method calls:

```python
dist.all_reduce(B)
```

Without checking:

```python
if dist.is_initalized():
```

This raises `ValueError: Default process group has not been initialized`
 when running iBOT Sinkhorn on a single GPU / single process.

This PR adds a conditional check to the reduction, matching the handling already seen in the rest of the method and the DINO sinkhorn_knopp_teacher method.


