### PR TITLE
dinov2: fix environment drift by pinning cuda-version=11.7 and deps

### DIFF
--- a/conda.yaml
+++ b/conda.yaml
@@ -1,22 +1,24 @@
 name: dinov2
 channels:
-  - defaults
   - pytorch
   - nvidia
-  - xformers
   - conda-forge
+  - rapidsai
 dependencies:
-  - python=3.9
-  - pytorch::pytorch=2.0.0
-  - pytorch::pytorch-cuda=11.7.0
-  - pytorch::torchvision=0.15.0
+  - python=3.10
+  - pip
+  - pytorch=2.0.0
+  - pytorch-cuda=11.7
+  - cuda-version=11.7
+  - torchvision=0.15.0
+  - mkl=2024.0.0
+  - numpy<2
+  - setuptools<81
   - omegaconf
   - torchmetrics=0.10.3
   - fvcore
   - iopath
-  - xformers::xformers=0.0.18
-  - pip
+  - cuml=24.02
   - pip:
-    - git+https://github.com/facebookincubator/submitit
-    - --extra-index-url https://pypi.nvidia.com
-    - cuml-cu11
+      - xformers==0.0.18
+      - submitit

--- a/dinov2/run/submit.py
+++ b/dinov2/run/submit.py
@@ -61,9 +61,19 @@ def get_args_parser(
         help="Partition where to submit",
     )
     parser.add_argument(
+        "--use-ampere80",
+        action="store_true",
+        help="Request A100-80GB GPUs",
+    )
+    parser.add_argument(
         "--use-volta32",
         action="store_true",
         help="Request V100-32GB GPUs",
+    )
+    parser.add_argument(
+        "--contiguous",
+        action="store_true",
+        help="Request contiguous nodes from Slurm",
     )
     parser.add_argument(
         "--comment",
@@ -97,12 +107,17 @@ def submit_jobs(task_class, args, name: str):
     executor = submitit.AutoExecutor(folder=args.output_dir, slurm_max_num_timeout=30)
 
     kwargs = {}
+    if args.use_ampere80:
+        kwargs["slurm_constraint"] = "ampere80gb"
     if args.use_volta32:
         kwargs["slurm_constraint"] = "volta32gb"
     if args.comment:
         kwargs["slurm_comment"] = args.comment
     if args.exclude:
         kwargs["slurm_exclude"] = args.exclude
+    if args.contiguous:
+        kwargs["slurm_additional_parameters"] = {"contiguous": True}
+
 
     executor_params = get_slurm_executor_parameters(
         nodes=args.nodes,


### PR DESCRIPTION
# Summary
This PR updates and stabilizes the conda.yaml environment used for DINOv2 training and evaluation.
The main goal is to improve reproducibility and avoid dependency drift/runtime mismatches while keeping the PyTorch 2.0 stack.

## What changed
Updated base env to Python 3.10

Kept core stack aligned to:
- pytorch==2.0.0
- pytorch-cuda==11.7
- torchvision==0.15.0

Added compatibility pins for stability:
- mkl=2024.0.0
- numpy<2
- setuptools<81
- cuda-version=11.7

Kept required runtime dependencies in env:
- xformers==0.0.18
- submitit
- cuml

## Why this is needed
During reproducibility testing, we hit environment-level issues including:
- Torch import/runtime mismatch (iJIT_NotifyEvent) resolved by pinning MKL.
- CUDA meta-package drift (cuda-version resolving to an unintended line) despite pytorch-cuda=11.7, resolved by explicitly pinning cuda-version=11.7.
- torchmetrics==0.10.3 requiring pkg_resources availability, handled by pinning setuptools<81.
- NumPy ABI compatibility warnings with NumPy 2.x, handled by pinning numpy<2.

This PR tightens the critical version boundaries so train/eval workflows are reproducible.

## Validation
Verified successful environment creation and imports (torch, xformers, submitit, cuml).
Verified training runs complete with the updated environment.
Verified eval entrypoints run with the updated dependency set.

<img width="1689" height="1361" alt="image" src="https://github.com/user-attachments/assets/73c9434f-64db-4207-8534-bfcc61b7aba2" />
<img width="1688" height="1361" alt="image2" src="https://github.com/user-attachments/assets/eff44de3-f3d5-414e-9ac3-2b8a7a165036" />
