### PR TITLE
Replace black/flake8/pylint with ruff

### DIFF
--- a/.github/workflows/lint.yaml
+++ b/.github/workflows/lint.yaml
@@ -25,14 +25,10 @@ jobs:
       - name: Install Python (development) dependencies
         run: |
           pip install -r requirements-dev.txt
-      - name: Run flake8
+      - name: Run ruff (lint)
         run: |
-          flake8
-      - name: Run black
+          ruff check dinov2
+      - name: Run ruff (format)
         if: always()
         run: |
-          black --check dinov2
-      - name: Run pylint
-        if: always()
-        run: |
-          pylint --exit-zero dinov2
+          ruff format --check dinov2

--- a/dinov2/data/datasets/cell_dino/hpafov.py
+++ b/dinov2/data/datasets/cell_dino/hpafov.py
@@ -164,7 +164,6 @@ def _load_file_names_and_labels(
     with open(csv_fpath) as filename:
         reader = csv.DictReader(filename)
         for row in reader:
-
             add_sample = True
             if mode != _Mode.PROTEIN_LOCALIZATION.value.upper():
                 # categorical

--- a/dinov2/data/datasets/image_net_22k.py
+++ b/dinov2/data/datasets/image_net_22k.py
@@ -215,7 +215,7 @@ class ImageNet22k(ExtendedVisionDataset):
                 with GzipFile(fileobj=BytesIO(data)) as g:
                     data = g.read()
         except Exception as e:
-            raise RuntimeError(f"can not retrieve image data for sample {index} " f'from "{class_id}" tarball') from e
+            raise RuntimeError(f'can not retrieve image data for sample {index} from "{class_id}" tarball') from e
 
         return data
 

--- a/dinov2/eval/cell_dino/knn.py
+++ b/dinov2/eval/cell_dino/knn.py
@@ -228,9 +228,10 @@ def eval_knn_with_leave_one_out(
     logger.info("Start the k-NN classification.")
 
     eval_metrics_dict = {}
-    postprocessors, metrics = {k: DictKeysModule([k]) for k in nb_knn}, {
-        k: metric_collection.clone().to(device) for k in nb_knn
-    }
+    postprocessors, metrics = (
+        {k: DictKeysModule([k]) for k in nb_knn},
+        {k: metric_collection.clone().to(device) for k in nb_knn},
+    )
     for metric_key in metrics.keys():
         metrics[metric_key] = metrics[metric_key].to(device)
 
@@ -427,9 +428,10 @@ def eval_knn(
         train_features, train_labels = train_data_dict[try_]["train_features"], train_data_dict[try_]["train_labels"]
         k_list = sorted(set([el if el < len(train_features) else len(train_features) for el in nb_knn]))
         knn_module = partial_knn_module(train_features=train_features, train_labels=train_labels, nb_knn=k_list)
-        postprocessors, metrics = {k: DictKeysModule([k]) for k in k_list}, {
-            k: metric_collection.clone() for k in k_list
-        }
+        postprocessors, metrics = (
+            {k: DictKeysModule([k]) for k in k_list},
+            {k: metric_collection.clone() for k in k_list},
+        )
         _, eval_metrics, _ = evaluate_with_accumulate(
             SequentialWithKwargs(model, knn_module),
             test_data_loader,

--- a/dinov2/eval/cell_dino/linear.py
+++ b/dinov2/eval/cell_dino/linear.py
@@ -951,7 +951,6 @@ def eval_linear_with_model(
     else:  # if leave one out is True
         test_results_dict = {}
         for loo_label in loo_dict.keys():
-
             checkpoint_output_dir, save_filename_suffix = os.path.join(output_dir, f"checkpoints_{loo_label}"), ""
             os.makedirs(checkpoint_output_dir, exist_ok=True)
 

--- a/dinov2/eval/depth/models/builder.py
+++ b/dinov2/eval/depth/models/builder.py
@@ -43,7 +43,7 @@ def build_loss(cfg):
 def build_depther(cfg, train_cfg=None, test_cfg=None):
     """Build depther."""
     if train_cfg is not None or test_cfg is not None:
-        warnings.warn("train_cfg and test_cfg is deprecated, " "please specify them in model", UserWarning)
+        warnings.warn("train_cfg and test_cfg is deprecated, please specify them in model", UserWarning)
     assert cfg.get("train_cfg") is None or train_cfg is None, "train_cfg specified in both outer field and model field "
     assert cfg.get("test_cfg") is None or test_cfg is None, "test_cfg specified in both outer field and model field "
     return DEPTHER.build(cfg, default_args=dict(train_cfg=train_cfg, test_cfg=test_cfg))

--- a/dinov2/eval/depth/models/decode_heads/dpt_head.py
+++ b/dinov2/eval/depth/models/decode_heads/dpt_head.py
@@ -231,7 +231,7 @@ class DPTHead(DepthBaseDecodeHead):
         readout_type="ignore",
         patch_size=16,
         expand_channels=False,
-        **kwargs
+        **kwargs,
     ):
         super(DPTHead, self).__init__(**kwargs)
 

--- a/dinov2/eval/depth/models/depther/base.py
+++ b/dinov2/eval/depth/models/depther/base.py
@@ -71,10 +71,10 @@ class BaseDepther(BaseModule, metaclass=ABCMeta):
         """
         for var, name in [(imgs, "imgs"), (img_metas, "img_metas")]:
             if not isinstance(var, list):
-                raise TypeError(f"{name} must be a list, but got " f"{type(var)}")
+                raise TypeError(f"{name} must be a list, but got {type(var)}")
         num_augs = len(imgs)
         if num_augs != len(img_metas):
-            raise ValueError(f"num of augmentations ({len(imgs)}) != " f"num of image meta ({len(img_metas)})")
+            raise ValueError(f"num of augmentations ({len(imgs)}) != num of image meta ({len(img_metas)})")
         # all images in the same aug batch all of the same ori_shape and pad
         # shape
         for img_meta in img_metas:

--- a/dinov2/eval/linear.py
+++ b/dinov2/eval/linear.py
@@ -244,9 +244,9 @@ def setup_linear_classifiers(sample_output, n_last_blocks_list, learning_rates, 
                     out_dim, use_n_blocks=n, use_avgpool=avgpool, num_classes=num_classes
                 )
                 linear_classifier = linear_classifier.cuda()
-                linear_classifiers_dict[
-                    f"classifier_{n}_blocks_avgpool_{avgpool}_lr_{lr:.5f}".replace(".", "_")
-                ] = linear_classifier
+                linear_classifiers_dict[f"classifier_{n}_blocks_avgpool_{avgpool}_lr_{lr:.5f}".replace(".", "_")] = (
+                    linear_classifier
+                )
                 optim_param_groups.append({"params": linear_classifier.parameters(), "lr": lr})
 
     linear_classifiers = AllClassifiers(linear_classifiers_dict)

--- a/dinov2/eval/segmentation_m2f/core/anchor/builder.py
+++ b/dinov2/eval/segmentation_m2f/core/anchor/builder.py
@@ -17,5 +17,5 @@ def build_prior_generator(cfg, default_args=None):
 
 
 def build_anchor_generator(cfg, default_args=None):
-    warnings.warn("``build_anchor_generator`` would be deprecated soon, please use " "``build_prior_generator`` ")
+    warnings.warn("``build_anchor_generator`` would be deprecated soon, please use ``build_prior_generator`` ")
     return build_prior_generator(cfg, default_args=default_args)

--- a/dinov2/eval/segmentation_m2f/models/backbones/vit.py
+++ b/dinov2/eval/segmentation_m2f/models/backbones/vit.py
@@ -27,6 +27,7 @@ for some einops/einsum fun
 
 Hacked together by / Copyright 2021 Ross Wightman
 """
+
 import logging
 import math
 from functools import partial

--- a/dinov2/eval/segmentation_m2f/models/backbones/vit_adapter.py
+++ b/dinov2/eval/segmentation_m2f/models/backbones/vit_adapter.py
@@ -37,7 +37,7 @@ class ViTAdapter(TIMMVisionTransformer):
         use_cls=True,
         with_cp=False,
         *args,
-        **kwargs
+        **kwargs,
     ):
 
         super().__init__(num_heads=num_heads, pretrained=pretrained, with_cp=with_cp, *args, **kwargs)

--- a/dinov2/eval/segmentation_m2f/models/losses/cross_entropy_loss.py
+++ b/dinov2/eval/segmentation_m2f/models/losses/cross_entropy_loss.py
@@ -119,11 +119,11 @@ def binary_cross_entropy(
     if pred.size(1) == 1:
         # For binary class segmentation, the shape of pred is
         # [N, 1, H, W] and that of label is [N, H, W].
-        assert label.max() <= 1, "For pred with shape [N, 1, H, W], its label must have at " "most 2 classes"
+        assert label.max() <= 1, "For pred with shape [N, 1, H, W], its label must have at most 2 classes"
         pred = pred.squeeze()
     if pred.dim() != label.dim():
         assert (pred.dim() == 2 and label.dim() == 1) or (pred.dim() == 4 and label.dim() == 3), (
-            "Only pred shape [N, C], label shape [N] or pred shape [N, C, " "H, W], label shape [N, H, W] are supported"
+            "Only pred shape [N, C], label shape [N] or pred shape [N, C, H, W], label shape [N, H, W] are supported"
         )
         # `weight` returned from `_expand_onehot_labels`
         # has been treated for valid (non-ignore) pixels

--- a/dinov2/eval/segmentation_m2f/models/utils/assigner.py
+++ b/dinov2/eval/segmentation_m2f/models/utils/assigner.py
@@ -142,7 +142,7 @@ class MaskHungarianAssigner(BaseAssigner):
         # 3. do Hungarian matching on CPU using linear_sum_assignment
         cost = cost.detach().cpu()
         if linear_sum_assignment is None:
-            raise ImportError('Please run "pip install scipy" ' "to install scipy first.")
+            raise ImportError('Please run "pip install scipy" to install scipy first.')
 
         matched_row_inds, matched_col_inds = linear_sum_assignment(cost)
         matched_row_inds = torch.from_numpy(matched_row_inds).to(cls_pred.device)

--- a/dinov2/eval/segmentation_m2f/models/utils/positional_encoding.py
+++ b/dinov2/eval/segmentation_m2f/models/utils/positional_encoding.py
@@ -43,7 +43,7 @@ class SinePositionalEncoding(BaseModule):
         super(SinePositionalEncoding, self).__init__(init_cfg)
         if normalize:
             assert isinstance(scale, (float, int)), (
-                "when normalize is set," "scale should be provided and in float or int type, " f"found {type(scale)}"
+                f"when normalize is set,scale should be provided and in float or int type, found {type(scale)}"
             )
         self.num_feats = num_feats
         self.temperature = temperature

--- a/dinov2/eval/segmentation_m2f/models/utils/transformer.py
+++ b/dinov2/eval/segmentation_m2f/models/utils/transformer.py
@@ -190,7 +190,7 @@ class PatchMerging(BaseModule):
                     (Merged_H, Merged_W).
         """
         B, L, C = x.shape
-        assert isinstance(input_size, Sequence), f"Expect " f"input_size is " f"`Sequence` " f"but get {input_size}"
+        assert isinstance(input_size, Sequence), f"Expect input_size is `Sequence` but get {input_size}"
 
         H, W = input_size
         assert L == H * W, "input feature has wrong size"
@@ -276,7 +276,7 @@ class FFN(BaseModule):
         **kwargs,
     ):
         super().__init__(init_cfg)
-        assert num_fcs >= 2, "num_fcs should be no less " f"than 2. got {num_fcs}."
+        assert num_fcs >= 2, f"num_fcs should be no less than 2. got {num_fcs}."
         self.embed_dims = embed_dims
         self.feedforward_channels = feedforward_channels
         self.num_fcs = num_fcs
@@ -374,7 +374,7 @@ class DetrTransformerEncoder(TransformerLayerSequence):
         if post_norm_cfg is not None:
             self.post_norm = build_norm_layer(post_norm_cfg, self.embed_dims)[1] if self.pre_norm else None
         else:
-            assert not self.pre_norm, f"Use prenorm in " f"{self.__class__.__name__}," f"Please specify post_norm_cfg"
+            assert not self.pre_norm, f"Use prenorm in {self.__class__.__name__},Please specify post_norm_cfg"
             self.post_norm = None
 
     def forward(self, *args, **kwargs):

--- a/dinov2/eval/segmentation_m2f/ops/modules/ms_deform_attn.py
+++ b/dinov2/eval/segmentation_m2f/ops/modules/ms_deform_attn.py
@@ -71,7 +71,7 @@ class MSDeformAttn(nn.Module):
         """
         super().__init__()
         if d_model % n_heads != 0:
-            raise ValueError("d_model must be divisible by n_heads, " "but got {} and {}".format(d_model, n_heads))
+            raise ValueError("d_model must be divisible by n_heads, but got {} and {}".format(d_model, n_heads))
         _d_per_head = d_model // n_heads
         # you'd better set _d_per_head to a power of 2
         # which is more efficient in our CUDA implementation

--- a/dinov2/hub/depth/encoder_decoder.py
+++ b/dinov2/hub/depth/encoder_decoder.py
@@ -227,10 +227,10 @@ class DepthEncoderDecoder(nn.Module):
         """
         for var, name in [(imgs, "imgs"), (img_metas, "img_metas")]:
             if not isinstance(var, list):
-                raise TypeError(f"{name} must be a list, but got " f"{type(var)}")
+                raise TypeError(f"{name} must be a list, but got {type(var)}")
         num_augs = len(imgs)
         if num_augs != len(img_metas):
-            raise ValueError(f"num of augmentations ({len(imgs)}) != " f"num of image meta ({len(img_metas)})")
+            raise ValueError(f"num of augmentations ({len(imgs)}) != num of image meta ({len(img_metas)})")
         # all images in the same aug batch all of the same ori_shape and pad
         # shape
         for img_meta in img_metas:

--- a/dinov2/train/ssl_meta_arch.py
+++ b/dinov2/train/ssl_meta_arch.py
@@ -348,9 +348,9 @@ class SSLMetaArch(nn.Module):
     def fsdp_synchronize_streams(self):
         if self.need_to_synchronize_fsdp_streams:
             torch.cuda.synchronize()
-            self.student.dino_head._streams = (
-                self.teacher.dino_head._streams
-            ) = self.student.backbone._streams = self.teacher.backbone._streams
+            self.student.dino_head._streams = self.teacher.dino_head._streams = self.student.backbone._streams = (
+                self.teacher.backbone._streams
+            )
             self.need_to_synchronize_fsdp_streams = False
 
     def update_teacher(self, m):

--- a/dinov2/train/train.py
+++ b/dinov2/train/train.py
@@ -95,9 +95,9 @@ def build_schedulers(cfg):
     teacher_temp_schedule = CosineScheduler(**teacher_temp)
     last_layer_lr_schedule = CosineScheduler(**lr)
 
-    last_layer_lr_schedule.schedule[
-        : cfg.optim["freeze_last_layer_epochs"] * OFFICIAL_EPOCH_LENGTH
-    ] = 0  # mimicking the original schedules
+    last_layer_lr_schedule.schedule[: cfg.optim["freeze_last_layer_epochs"] * OFFICIAL_EPOCH_LENGTH] = (
+        0  # mimicking the original schedules
+    )
 
     logger.info("Schedulers ready.")
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,29 +1,14 @@
-[tool.black]
+[tool.ruff]
 line-length = 120
+target-version = "py39"
 
-[tool.pylint.master]
-persistent = false
-score = false
+[tool.ruff.lint]
+select = ["E", "F", "W"]
+ignore = ["E203", "E501"]
 
-[tool.pylint.messages_control]
-disable = "all"
-enable = [
-  "miscellaneous",
-  "similarities",
-]
+[tool.ruff.lint.per-file-ignores]
+"__init__.py" = ["F401"]
+"hubconf.py" = ["F401"]
 
-[tool.pylint.similarities]
-ignore-comments = true
-ignore-docstrings = true
-ignore-imports = true
-min-similarity-lines = 8
-
-[tool.pylint.reports]
-reports = false
-
-[tool.pylint.miscellaneous]
-notes = [
-  "FIXME",
-  "XXX",
-  "TODO",
-]
+[tool.ruff.format]
+# ruff format is black-compatible by default

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,3 +1,1 @@
-black==22.6.0
-flake8==5.0.4
-pylint==2.15.0
+ruff

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,8 +1,0 @@
-[flake8]
-max-line-length = 120
-ignore = E203,E501,W503
-per-file-ignores =
-  __init__.py:F401
-  hubconf.py:F401
-exclude =
-    venv


### PR DESCRIPTION
## Summary

- Drops `black==22.6.0`, `flake8==5.0.4`, and `pylint==2.15.0` from `requirements-dev.txt` in favor of a single `ruff` dependency
- Migrates `[tool.black]` (from `pyproject.toml`) and `[flake8]` (from `setup.cfg`) config into `[tool.ruff]` / `[tool.ruff.lint]` / `[tool.ruff.format]` — preserving the existing `line-length = 120`, ignored codes (`E203`, `E501`), and per-file ignores for `__init__.py` and `hubconf.py`
- Removes the now-empty `setup.cfg`
- Updates `.github/workflows/lint.yaml` to use `ruff check` and `ruff format --check` instead of three separate tool invocations
- Applies `ruff format` to 19 files whose formatting had drifted from black's output; all other source files are unchanged

## Motivation

The current dev toolchain uses three separate tools pinned to versions from 2022. ruff replaces all three, runs 10–100x faster, and is configured in one place (`pyproject.toml`). There is an open dependabot PR (#589) just to bump black — this supersedes it.

`ruff check` and `ruff format --check` both pass cleanly on the full codebase after this change.

## Test plan

- [x] `pip install -r requirements-dev.txt` installs cleanly
- [x] `ruff check dinov2` → `All checks passed!`
- [x] `ruff format --check dinov2` → `155 files already formatted`
- [ ] CI lint workflow passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)